### PR TITLE
Improve mobile variant

### DIFF
--- a/app/assets/javascript/pageflow/outline_navigation_bar/events.js
+++ b/app/assets/javascript/pageflow/outline_navigation_bar/events.js
@@ -1,30 +1,34 @@
-pageflow.outlineNavigationBar.events = {
-  pointerUp: 'touchend mouseup MSPointerUp pointerup',
-  pointerDown: 'touchstart mousedown MSPointerDown pointerdown',
+pageflow.outlineNavigationBar.events = (function() {
+  var hasPointerEvents = window.PointerEvent || window.MSPointerEvent;
 
-  onPointerDown: function(element, selectorOrHandler, handler) {
-    var selector = handler ? selectorOrHandler : null;
-    handler = handler || selectorOrHandler;
+  return {
+    pointerUp: hasPointerEvents ? 'MSPointerUp pointerup mouseup' : 'touchend mouseup',
+    pointerDown: hasPointerEvents ? 'MSPointerDown pointerdown mousedown' : 'touchstart mousedown',
 
-    this._onPointerDown(handler, function(event, fn) {
-      element.on(event, selector, fn);
-    });
-  },
+    onPointerDown: function(element, selectorOrHandler, handler) {
+      var selector = handler ? selectorOrHandler : null;
+      handler = handler || selectorOrHandler;
 
-  _onPointerDown: function(handler, on) {
-    on(this.pointerDown, function(event) {
-      event.preventDefault();
-      handler.call(this);
-    });
+      this._onPointerDown(handler, function(event, fn) {
+        element.on(event, selector, fn);
+      });
+    },
 
-    on('click', function(event) {
-      event.preventDefault();
-    });
-
-    on('keypress', function(event) {
-      if (event.which == 13) {
+    _onPointerDown: function(handler, on) {
+      on(this.pointerDown, function(event) {
+        event.preventDefault();
         handler.call(this);
-      }
-    });
-  },
-};
+      });
+
+      on('click', function(event) {
+        event.preventDefault();
+      });
+
+      on('keypress', function(event) {
+        if (event.which == 13) {
+          handler.call(this);
+        }
+      });
+    },
+  };
+}());

--- a/app/assets/javascript/pageflow/outline_navigation_bar/widget.js
+++ b/app/assets/javascript/pageflow/outline_navigation_bar/widget.js
@@ -38,7 +38,7 @@
           widget.resizer.expand();
           widget.scroller.expand();
 
-          if (mobileLayout()) {
+          if (phoneLayout()) {
             hidePageContent();
           }
         },
@@ -212,7 +212,11 @@
   });
 
   function mobileLayout() {
-    return ($('body').width() <= 900);
+    return ($('body').width() <= 900) || pageflow.browser.has('mobile platform');
+  }
+
+  function phoneLayout() {
+    return ($('body').width() <= 700);
   }
 
   function hidePageContent() {

--- a/app/assets/stylesheets/pageflow/outline_navigation_bar/themes/default/parent_page_button.scss
+++ b/app/assets/stylesheets/pageflow/outline_navigation_bar/themes/default/parent_page_button.scss
@@ -4,7 +4,7 @@
   cursor: pointer;
   pointer-events: all;
   position: absolute;
-  top: 0;
+  top: 15px;
   left: -105px;
   width: 45px;
   height: 45px;

--- a/app/assets/stylesheets/pageflow/outline_navigation_bar/themes/default/toggle.scss
+++ b/app/assets/stylesheets/pageflow/outline_navigation_bar/themes/default/toggle.scss
@@ -2,6 +2,10 @@
   height: 45px;
   position: absolute;
 
+  &.chapters {
+    top: 15px;
+  }
+
   &.share,
   &.credits {
     opacity: 0;


### PR DESCRIPTION
* Prevent toggling panel twice (which feels like no toggling at all)
  when both touch events and pointer events are supported.

* Ensure mobile variant is consistently used on mobile platforms, not
  only when the mobile media query matches. Even on landscape iPad
  (which does not match the mobile media query), the fixed navigation
  bar gets in the way.