### PR TITLE
Fix new share icons in sprite variant (1.3 Backport)

### DIFF
--- a/app/assets/stylesheets/pageflow/outline_navigation_bar/themes/default/icons/sprite.scss
+++ b/app/assets/stylesheets/pageflow/outline_navigation_bar/themes/default/icons/sprite.scss
@@ -63,10 +63,6 @@
   }
 
   .share_box {
-    a.share {
-      width: 39px;
-    }
-
     .button {
       margin-left: 5px;
     }


### PR DESCRIPTION
Backport of #10 

No need to set the width anymore.

REDMINE-16728